### PR TITLE
Social widgets revamp

### DIFF
--- a/public/localization/en-us.json
+++ b/public/localization/en-us.json
@@ -4,7 +4,7 @@
   },
   "generic" : {
     "CONNECT": "Get connected",
-    "OUT_BLOG": "OUR BLOG",
+    "OUR_BLOG": "OUR BLOG",
     "READ_MORE": "Read more",
     "RSS_TITLE": "CB BLOG"
   }

--- a/templates/elements/rss.html
+++ b/templates/elements/rss.html
@@ -1,10 +1,9 @@
-<div class="cbcolumn col-md-4 col-sm-12 col-xs-12">
-  <p class="forcB">loc_RSS_TITLE</p>
+<div class="rss-widget">
   <div class="socialDesc blog">
-    <p class="forNdemi">^post_text^</p>
-    <a href="^post_url^" class="links">^loc_READ_MORE^</a><span class="forNbook">^post_posted^</span>
+    <p class="rss-post-body">^post_text^</p>
+    <a href="^post_url^" class="rss-read-more">^loc_READ_MORE^</a> <span class="rss-date-posted">^post_posted^</span>
   </div>
-  <div class="connect text-center">
-    <p><span class="uppercase">^loc_CONNECT^</span> <a href="^blog_url^"><span class="fbTxt"><b>loc_OUR_BLOG</b></span></a><span class="txtOrange splC">></span></p>
+  <div class="rss-connect-block">
+    <p><span class="rss-get-connected-message">^loc_CONNECT^</span> <a href="^blog_url^"><span class="rss-full-blog-link"><b>^loc_OUR_BLOG^</b></span></a></p>
   </div>
 </div>

--- a/templates/elements/rss.html
+++ b/templates/elements/rss.html
@@ -3,7 +3,7 @@
     <p class="rss-post-body">^post_text^</p>
     <a href="^post_url^" class="rss-read-more">^loc_READ_MORE^</a> <span class="rss-date-posted">^post_posted^</span>
   </div>
-  <div class="rss-connect-block">
+  <div class="rss-get-connected-section">
     <p><span class="rss-get-connected-message">^loc_CONNECT^</span> <a href="^blog_url^"><span class="rss-full-blog-link"><b>^loc_OUR_BLOG^</b></span></a></p>
   </div>
 </div>


### PR DESCRIPTION
This is a revamp of alex's revamp.  Namely reformatted HTML and localized the widget template.  The CBC specific version has been moved back into CBC to allow for it to be a theme level override to keep the original and expected behavior for CBC while allowing for the most flexibility for future premium sites instead of locking them into the CBC specific styles.
